### PR TITLE
Fix #31: Make the hint text bolder.

### DIFF
--- a/django_netjsonconfig/static/django-netjsonconfig/css/admin.css
+++ b/django_netjsonconfig/static/django-netjsonconfig/css/admin.css
@@ -96,3 +96,8 @@
 #container .help a,
 #netjsonconfig-hint a{ text-decoration: underline }
 #netjsonconfig-hint{ width: auto }
+
+.sortedm2m-container .help{
+    color: #333;
+    font-weight: bold;
+}


### PR DESCRIPTION
This PR makes the hint-text "Choose items and order by drag & drop." bolder by changing add a little css to the admin.css file.