### PR TITLE
Fix a grammar error

### DIFF
--- a/django_netjsonconfig/base/config.py
+++ b/django_netjsonconfig/base/config.py
@@ -99,7 +99,7 @@ class TemplatesVpnMixin(models.Model):
                                       related_name='config_relations',
                                       verbose_name=_('templates'),
                                       blank=True,
-                                      help_text=_('configuration templates, applied from'
+                                      help_text=_('configuration templates, applied from '
                                                   'first to last'))
     vpn = models.ManyToManyField('django_netjsonconfig.Vpn',
                                  through='django_netjsonconfig.VpnClient',


### PR DESCRIPTION
A very simple grammar error that I've found while going through the site. This PR adds space between two words which might have been neglected earlier. Between from and first in the below screenshot.

![gramerr](https://cloud.githubusercontent.com/assets/13820931/23580416/719f1b72-0127-11e7-95f8-b795e4528851.png)
