### PR TITLE
[config-editor] added ability to disable schema validation

### DIFF
--- a/django_netjsonconfig/static/django-netjsonconfig/js/widget.js
+++ b/django_netjsonconfig/static/django-netjsonconfig/js/widget.js
@@ -30,10 +30,12 @@
         }
     }
 
-    var initAdvancedEditor = function(target, data, schema){
+    var initAdvancedEditor = function(target, data, schema, disableSchema){
         var advanced = $("<div id='advanced_editor'></div>");
         $(advanced).insertBefore($(target));
         $(target).hide();
+        // if disableSchema is true, do not validate againsts schema, default is false
+        schema = disableSchema ? {} : schema;
         var options = {
             mode:'code',
             theme: 'ace/theme/tomorrow_night_bright',


### PR DESCRIPTION
PR pertaining to issue #55 
I have added the possibility to disable validation to the advanced mode editor.
So to disable the validation all that needs to be done is to pass a fourth parameter as true to the initAdvancedEditor method.