### PR TITLE
[controller] register view should update device details #81

### DIFF
--- a/django_netjsonconfig/controller/generics.py
+++ b/django_netjsonconfig/controller/generics.py
@@ -192,8 +192,7 @@ class BaseRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
             config.device = device
         # update last_ip field of device
         device.last_ip = request.META.get('REMOTE_ADDR')
-
-        #update os,model and system fields of device
+        # update os,model and system fields of device
         os = request.POST.get('os')
         model = request.POST.get('model')
         system = request.POST.get('system')
@@ -202,7 +201,6 @@ class BaseRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
             device.model = model
             device.system = system
         # validate and save everything or fail otherwise
-
         try:
             device.full_clean()
             device.save()

--- a/django_netjsonconfig/controller/generics.py
+++ b/django_netjsonconfig/controller/generics.py
@@ -192,7 +192,17 @@ class BaseRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
             config.device = device
         # update last_ip field of device
         device.last_ip = request.META.get('REMOTE_ADDR')
+
+        #update os,model and system fields of device
+        os = request.POST.get('os')
+        model = request.POST.get('model')
+        system = request.POST.get('system')
+        if os is not None and model is not None and system is not None:
+            device.os = os
+            device.model = model
+            device.system = system
         # validate and save everything or fail otherwise
+
         try:
             device.full_clean()
             device.save()


### PR DESCRIPTION
The 0.4.6 version of openWrt, sends the information to fill the fields model, Operating system and SOC / CPU, if the device with the new version is not present on openwisp, has never been added, the fields are correctly filled, while when updating a device already present on openwisp, the fields are not updated.

[Possible BUG: model, OS and CPU fields not filled in the controller after openwisp-config upgrade](https://groups.google.com/forum/#!topic/openwisp/VTU4PH6u7oE)

Refers to #82.