### PR TITLE
[requirements] Added support for Django 2.1 #87

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ sudo: false
 cache: pip
 
 python:
-  - "3.4"
+  - "3.5"
   - "2.7"
 
 env:
   - DJANGO="django>=1.11,<1.12"
-  - DJANGO="django>=2.0,<2.1"
+  - DJANGO="django>=2.0,<2.2"
 
 matrix:
   exclude:
    - python: "2.7"
-     env: DJANGO="django>=2.0,<2.1"
+     env: DJANGO="django>=2.0,<2.2"
 
 branches:
   only:
@@ -33,7 +33,7 @@ install:
 
 script:
   - coverage run --source=django_netjsonconfig runtests.py
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then ./tests/manage.py makemigrations --dry-run | grep "No changes detected"; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then ./tests/manage.py makemigrations --dry-run | grep "No changes detected"; fi
 
 after_success:
   coveralls

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ An automated installer is available at `ansible-openwisp2 <https://github.com/op
 Dependencies
 ------------
 
-* Python 2.7 or Python >= 3.4
+* Python 2.7 or Python >= 3.5
 * OpenSSL
 
 Install stable version from pypi

--- a/django_netjsonconfig/widgets.py
+++ b/django_netjsonconfig/widgets.py
@@ -37,5 +37,5 @@ class JsonSchemaWidget(AdminTextareaWidget):
 """
         html = html.format(_('Advanced mode (raw JSON)'),
                            reverse('netjsonconfig:schema'))
-        html += super(JsonSchemaWidget, self).render(name, value, attrs)
+        html += super(JsonSchemaWidget, self).render(name, value, attrs, renderer)
         return html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=1.11,<2.1
+django>=1.11,<2.2
 django-model-utils
 jsonfield
 six
@@ -6,5 +6,5 @@ netjsonconfig>=0.6.2,<0.7.0
 django-sortedm2m>=1.5.0,<1.6
 django-reversion>=2.0.6,<3.1.0
 django-x509>=0.4.0,<0.5.0
-django-taggit>=0.22.2,<0.23.0
+django-taggit>=0.23.0,<0.24.0
 openwisp-utils>=0.2,<0.3

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
         'Framework :: Django',
         'Topic :: System :: Networking',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ]
 )


### PR DESCRIPTION
Added support for `Django 2.1`. From now `django-netjsonconfig` doesn't support `python 3.4`, so now the recommend version of `python` is `python 3.5` or higher.