### PR TITLE
[requirements] Use reversion 3.0.4 max

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ jsonfield
 six
 netjsonconfig>=0.6.2,<0.7.0
 django-sortedm2m>=1.5.0,<1.6
-django-reversion>=2.0.6,<3.1.0
+django-reversion>=2.0.6,<3.0.5
 django-x509>=0.4.0,<0.5.0
 django-taggit>=0.23.0,<0.24.0
 openwisp-utils>=0.2,<0.3


### PR DESCRIPTION
reversion 3.0.5 dropped python 2 support.