### PR TITLE
release 0.10.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,14 @@
 Changelog
 =========
 
+Version 0.10.1 [2020-02-06]
+---------------------------
+
+- Dropped django-x509<0.6.1 support
+- Dropped django-reversion<=3.0.5 support
+
 Version 0.10.0 [2020-01-24]
---------------------------
+---------------------------
 
 - Dropped support for python 2 & python<3.6
 - Dropped support for django<2.2

--- a/django_netjsonconfig/__init__.py
+++ b/django_netjsonconfig/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 10, 0, 'final')
+VERSION = (0, 10, 1, 'final')
 __version__ = VERSION  # alias
 
 


### PR DESCRIPTION
Version 0.10.1 [2020-02-06]
--------------------------

- Dropped django-x509<0.6.1 support
- Dropped django-reversion<=3.0.5 support

Signed-off-by: Ajay Tripathi <ajay39in@gmail.com>