### PR TITLE
[controller] Fix registration of an existing device

### DIFF
--- a/django_netjsonconfig/controller/generics.py
+++ b/django_netjsonconfig/controller/generics.py
@@ -207,11 +207,11 @@ class BaseDeviceRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
         new = False
         try:
             device = self.model.objects.get(key=key)
-            config = device.config
             # update hw info
             for attr in self.UPDATABLE_FIELDS:
                 if attr in request.POST:
                     setattr(device, attr, request.POST.get(attr))
+            config = device.config
         # if get queryset fails, instantiate a new Device and Config
         except self.model.DoesNotExist:
             new = True

--- a/django_netjsonconfig/tests/test_controller.py
+++ b/django_netjsonconfig/tests/test_controller.py
@@ -386,6 +386,30 @@ class TestController(CreateConfigMixin, CreateTemplateMixin, TestCase, TestVpnX5
         self.assertEqual(d.system, params['system'])
         self.assertEqual(d.model, params['model'])
 
+    def test_device_registration_update_hw_info_no_config(self):
+        d = self._create_device()
+        d.key = TEST_CONSISTENT_KEY
+        d.save()
+        params = {
+            'secret': settings.NETJSONCONFIG_SHARED_SECRET,
+            'name': TEST_MACADDR,
+            'mac_address': TEST_MACADDR,
+            'key': TEST_CONSISTENT_KEY,
+            'backend': 'netjsonconfig.OpenWrt',
+            'model': 'TP-Link TL-WDR4300 v2',
+            'os': 'OpenWrt 18.06-SNAPSHOT r7312-e60be11330',
+            'system': 'Atheros AR9344 rev 3'
+        }
+        self.assertNotEqual(d.os, params['os'])
+        self.assertNotEqual(d.system, params['system'])
+        self.assertNotEqual(d.model, params['model'])
+        response = self.client.post(REGISTER_URL, params)
+        self.assertEqual(response.status_code, 201)
+        d.refresh_from_db()
+        self.assertEqual(d.os, params['os'])
+        self.assertEqual(d.system, params['system'])
+        self.assertEqual(d.model, params['model'])
+
     def test_device_report_status_running(self):
         """
         maintained for backward compatibility


### PR DESCRIPTION
Related to https://github.com/openwisp/openwisp-config/issues/58, this fixes setting the HW and firmware info when a device is registered which already exists on the controller.