### PR TITLE
[x509] VPN files have 0600 permissions by default #169

### DIFF
--- a/django_netjsonconfig/tests/test_vpn.py
+++ b/django_netjsonconfig/tests/test_vpn.py
@@ -146,17 +146,17 @@ class TestVpn(TestVpnX509Mixin, CreateConfigMixin,
         control['files'] = [
             {
                 'path': context_keys['ca_path'],
-                'mode': '0644',
+                'mode': '0600',
                 'contents': context_keys['ca_contents']
             },
             {
                 'path': context_keys['cert_path'],
-                'mode': '0644',
+                'mode': '0600',
                 'contents': context_keys['cert_contents']
             },
             {
                 'path': context_keys['key_path'],
-                'mode': '0644',
+                'mode': '0600',
                 'contents': context_keys['key_contents']
             }
         ]
@@ -176,7 +176,7 @@ class TestVpn(TestVpnX509Mixin, CreateConfigMixin,
         control['files'] = [
             {
                 'path': context_keys['ca_path'],
-                'mode': '0644',
+                'mode': '0600',
                 'contents': context_keys['ca_contents']
             }
         ]

--- a/django_netjsonconfig/vpn_backends.py
+++ b/django_netjsonconfig/vpn_backends.py
@@ -26,22 +26,22 @@ limited_schema['definitions']['server']['properties']['dh']['default'] = 'dh.pem
 limited_schema['properties']['files']['default'] = [
     {
         "path": "ca.pem",
-        "mode": "0644",
+        "mode": "0600",
         "contents": "{{ ca }}"
     },
     {
         "path": "cert.pem",
-        "mode": "0644",
+        "mode": "0600",
         "contents": "{{ cert }}"
     },
     {
         "path": "key.pem",
-        "mode": "0644",
+        "mode": "0600",
         "contents": "{{ key }}"
     },
     {
         "path": "dh.pem",
-        "mode": "0644",
+        "mode": "0600",
         "contents": "{{ dh }}"
     }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django>=2.2,<3.1
 django-model-utils>=4.0
-netjsonconfig>=0.7.0,<0.8.0
+netjsonconfig>=0.8.0,<0.9.0
 django-sortedm2m>=3.0.0,<3.1.0
 django-reversion>=3.0.5,<3.1.0
 django-x509>=0.6.2,<0.7.0

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -9,7 +9,7 @@ ALLOWED_HOSTS = []
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'netjsonconfig.db',
+        'NAME': os.path.join(BASE_DIR, 'netjsonconfig.db'),
     }
 }
 


### PR DESCRIPTION
Set default permission of files to 0600 and modified tests accordingly.
Minor fix in tests/settings.py
Closes #169
Applies changes from https://github.com/openwisp/netjsonconfig/pull/148/

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/32094433/78182935-b9353b00-7484-11ea-8341-125b6b393951.gif)

