### PR TITLE
[settings] Added HARDWARE_ID_AS_NAME

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -476,6 +476,20 @@ Options for the model field ``hardware_id``.
 * ``verbose_name``: text for the human readable label of the field
 * ``help_text``: help text to be displayed with the field
 
+``NETJSONCONFIG_HARDWARE_ID_AS_NAME``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++--------------+-------------+
+| **type**:    | ``bool``    |
++--------------+-------------+
+| **default**: | ``False``   |
++--------------+-------------+
+
+When the hardware ID feature is enabled, devices will be referenced with
+their hardware ID instead of their name.
+
+If you still want to reference devices by their name, set this to ``True``.
+
 Extending django-netjsonconfig
 ------------------------------
 

--- a/django_netjsonconfig/base/device.py
+++ b/django_netjsonconfig/base/device.py
@@ -56,6 +56,10 @@ class AbstractDevice(BaseModel):
     class Meta:
         abstract = True
 
+    def __str__(self):
+        return self.hardware_id if (app_settings.HARDWARE_ID_ENABLED
+                                    and app_settings.HARDWARE_ID_AS_NAME) else self.name
+
     def clean(self):
         """
         modifies related config status if name

--- a/django_netjsonconfig/settings.py
+++ b/django_netjsonconfig/settings.py
@@ -32,3 +32,4 @@ HARDWARE_ID_OPTIONS = {
     'help_text': _('Serial number of this device')
 }
 HARDWARE_ID_OPTIONS.update(getattr(settings, 'NETJSONCONFIG_HARDWARE_ID_OPTIONS', {}))
+HARDWARE_ID_AS_NAME = getattr(settings, 'NETJSONCONFIG_HARDWARE_ID_AS_NAME', True)

--- a/django_netjsonconfig/tests/test_device.py
+++ b/django_netjsonconfig/tests/test_device.py
@@ -17,9 +17,15 @@ class TestDevice(CreateConfigMixin, TestCase):
     config_model = Config
     device_model = Device
 
-    def test_str(self):
+    @mock.patch('django_netjsonconfig.settings.HARDWARE_ID_AS_NAME', False)
+    def test_str_name(self):
         d = Device(name='test')
         self.assertEqual(str(d), 'test')
+
+    @mock.patch('django_netjsonconfig.settings.HARDWARE_ID_AS_NAME', True)
+    def test_str_hardware_id(self):
+        d = Device(name='test', hardware_id='123')
+        self.assertEqual(str(d), '123')
 
     def test_mac_address_validator(self):
         d = Device(name='test',


### PR DESCRIPTION
Related to https://github.com/openwisp/openwisp-controller/issues/177.

Maintained default behaviour.