### PR TITLE
[docs] Fix description of NETJSONCONFIG_HARDWARE_ID_AS_NAME

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -482,13 +482,13 @@ Options for the model field ``hardware_id``.
 +--------------+-------------+
 | **type**:    | ``bool``    |
 +--------------+-------------+
-| **default**: | ``False``   |
+| **default**: | ``True``   |
 +--------------+-------------+
 
 When the hardware ID feature is enabled, devices will be referenced with
 their hardware ID instead of their name.
 
-If you still want to reference devices by their name, set this to ``True``.
+If you still want to reference devices by their name, set this to ``False``.
 
 Extending django-netjsonconfig
 ------------------------------


### PR DESCRIPTION
The values are the other way around.